### PR TITLE
incrase the default RLIMIT_AS limit to 4GiB. 512MiB is not enough for…

### DIFF
--- a/cmdline.cc
+++ b/cmdline.cc
@@ -391,11 +391,11 @@ std::unique_ptr<nsjconf_t> parseArgs(int argc, char* argv[]) {
 	nsjconf->keep_env = false;
 	nsjconf->keep_caps = false;
 	nsjconf->disable_no_new_privs = false;
-	nsjconf->rl_as = 512 * (1024 * 1024);
-	nsjconf->rl_core = 0;
-	nsjconf->rl_cpu = 600;
-	nsjconf->rl_fsize = 1 * (1024 * 1024);
-	nsjconf->rl_nofile = 32;
+	nsjconf->rl_as = 4096ULL * (1024ULL * 1024ULL);
+	nsjconf->rl_core = 0ULL;
+	nsjconf->rl_cpu = 600ULL;
+	nsjconf->rl_fsize = 1ULL * (1024ULL * 1024ULL);
+	nsjconf->rl_nofile = 32ULL;
 	nsjconf->rl_nproc = parseRLimit(RLIMIT_NPROC, "soft", 1);
 	nsjconf->rl_stack = parseRLimit(RLIMIT_STACK, "soft", 1);
 	nsjconf->personality = 0;

--- a/config.proto
+++ b/config.proto
@@ -142,7 +142,7 @@ message NsJailConfig {
 
     /* Various rlimits, the rlimit_as/rlimit_core/... are used only if
        rlimit_as_type/rlimit_core_type/... are set to RLimit::VALUE */
-    optional uint64 rlimit_as = 28 [default = 512]; /* In MiB */
+    optional uint64 rlimit_as = 28 [default = 4096]; /* In MiB */
     optional RLimit rlimit_as_type = 29 [default = VALUE];
     optional uint64 rlimit_core = 30 [default = 0]; /* In MiB */
     optional RLimit rlimit_core_type = 31 [default = VALUE];


### PR DESCRIPTION
… many payloas, and cgroups should be used for memory limiting anyway